### PR TITLE
918269: Resolved the drag and drop issue in NodeJS service.

### DIFF
--- a/filesystem-server.js
+++ b/filesystem-server.js
@@ -775,7 +775,7 @@ function FileManagerDirectoryContent(req, res, filepath, searchFilterPath) {
             if (searchFilterPath) {
                 cwd.filterPath = searchFilterPath;
             } else {
-                cwd.filterPath = (req.body.data.length > 0 && req.body.path != "/") ? path.normalize(req.body.path).replace(/^(\.\.[\/\\])+/, '').replace(/\\/g, '/') : "";
+                cwd.filterPath = req.body.data.length > 0 ? req.body.data[0].filterPath : "";
             }
             cwd.permission = getPathPermission(req.path, cwd.isFile, (req.body.path == "/") ? "" : cwd.name, filepath, contentRootPath, cwd.filterPath);
             if (fs.lstatSync(filepath).isFile()) {

--- a/filesystem-server.js
+++ b/filesystem-server.js
@@ -775,7 +775,7 @@ function FileManagerDirectoryContent(req, res, filepath, searchFilterPath) {
             if (searchFilterPath) {
                 cwd.filterPath = searchFilterPath;
             } else {
-                cwd.filterPath = req.body.data.length > 0 ? req.body.data[0].filterPath : "";
+                cwd.filterPath = (req.body.data.length > 0 && req.body.path != "/") ? path.normalize(req.body.data[0].filterPath).replace(/^(\.\.[\/\\])+/, '').replace(/\\/g, '/') : "";
             }
             cwd.permission = getPathPermission(req.path, cwd.isFile, (req.body.path == "/") ? "" : cwd.name, filepath, contentRootPath, cwd.filterPath);
             if (fs.lstatSync(filepath).isFile()) {

--- a/filesystem-server.js
+++ b/filesystem-server.js
@@ -775,7 +775,7 @@ function FileManagerDirectoryContent(req, res, filepath, searchFilterPath) {
             if (searchFilterPath) {
                 cwd.filterPath = searchFilterPath;
             } else {
-                cwd.filterPath = req.body.data.length > 0 ? path.normalize(req.body.path).replace(/^(\.\.[\/\\])+/, '').replace(/\\/g, '/') : "";
+                cwd.filterPath = req.body.data.length > 0 && req.body.path == "/" ? path.normalize(req.body.path).replace(/^(\.\.[\/\\])+/, '').replace(/\\/g, '/') : "";
             }
             cwd.permission = getPathPermission(req.path, cwd.isFile, (req.body.path == "/") ? "" : cwd.name, filepath, contentRootPath, cwd.filterPath);
             if (fs.lstatSync(filepath).isFile()) {

--- a/filesystem-server.js
+++ b/filesystem-server.js
@@ -775,7 +775,7 @@ function FileManagerDirectoryContent(req, res, filepath, searchFilterPath) {
             if (searchFilterPath) {
                 cwd.filterPath = searchFilterPath;
             } else {
-                cwd.filterPath = req.body.data.length > 0 && req.body.path == "/" ? path.normalize(req.body.path).replace(/^(\.\.[\/\\])+/, '').replace(/\\/g, '/') : "";
+                cwd.filterPath = (req.body.data.length > 0 && req.body.path != "/") ? path.normalize(req.body.path).replace(/^(\.\.[\/\\])+/, '').replace(/\\/g, '/') : "";
             }
             cwd.permission = getPathPermission(req.path, cwd.isFile, (req.body.path == "/") ? "" : cwd.name, filepath, contentRootPath, cwd.filterPath);
             if (fs.lstatSync(filepath).isFile()) {


### PR DESCRIPTION
**Description:**
Need to resolve the console error while performing drag and drop action in File Manager component Node JS service provider.
**Solution:**
The reported issue occurs due to setting incorrect filter path for current root folder in Node JS service read operation after performing duplicate copy/move operation. Also, ensured the changes with nested level and ensured the changes with GitHub code scanning.